### PR TITLE
sync with upstream @ v0.4.15

### DIFF
--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -15,7 +15,7 @@
 # Standard
 from collections.abc import Sized
 from enum import Enum, auto
-from typing import Callable, Dict, List, NamedTuple, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, TypeVar, Union
 import importlib
 import os
 import time
@@ -177,6 +177,20 @@ class EmbeddingModule(ModuleBase):
         model.encode("warmup")
 
         return cls(model)
+
+    @property
+    def public_model_info(cls) -> Dict[str, Any]:  # pylint: disable=no-self-argument
+        """Helper property to return public metadata about a specific Model. This
+        function is separate from `metdata` as that contains the entire ModelConfig
+        which might not want to be shared/exposed.
+
+        Returns:
+            Dict[str, str]: A dictionary of this models's public metadata
+        """
+        return {
+            "max_seq_length": cls.model.max_seq_length,
+            "sentence_embedding_dimension": cls.model.get_sentence_embedding_dimension(),
+        }
 
     @classmethod
     def _get_ipex(cls, ipex_flag):

--- a/caikit_nlp/modules/text_generation/peft_tgis_remote.py
+++ b/caikit_nlp/modules/text_generation/peft_tgis_remote.py
@@ -14,7 +14,9 @@
 """This file contains a distributed backend implementation for leveraging the PEFT-trained
 prompt vectors in TGIS generation requests.
 """
+
 # Standard
+from functools import cached_property
 from typing import Iterable, List, Optional, Tuple, Union
 import os
 
@@ -32,6 +34,7 @@ from caikit.interfaces.nlp.data_model import (
     TokenizationResults,
 )
 from caikit.interfaces.nlp.tasks import TextGenerationTask, TokenizationTask
+from caikit.interfaces.runtime.data_model import RuntimeServerContextType
 from caikit_tgis_backend import TGISBackend
 import alog
 
@@ -68,15 +71,14 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
         prompt_artifacts: Optional[List[str]] = None,
     ) -> None:
         super().__init__()
-        # Configure the internal client
-        # NOTE: This is made optional for the cases where we do not need to execute `.run` function
-        # for example, bootstrapping a model to caikit format and saving.
-        self._client = None
+
         self._tgis_backend = tgis_backend
         if enable_backend:
+            error.type_check(
+                "<NLP33971947E>", TGISBackend, tgis_backend=self._tgis_backend
+            )
             # get_client will also launch a local TGIS process and get the model
             # loaded when using the local TGIS backend
-            self._client = tgis_backend.get_client(base_model_name)
 
             # Tell the backend to load all of the available prompt files
             if prompt_artifacts:
@@ -106,6 +108,14 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             model_id = getattr(self, "base_model_name", None)
             if tgis_backend and prompt_cache_id and model_id:
                 tgis_backend.unload_prompt_artifacts(model_id, prompt_cache_id)
+
+    @cached_property
+    def _client(self):
+        # Configure the internal client
+        # NOTE: This is made optional for the cases where we do not need to execute `.run` function
+        # for example, bootstrapping a model to caikit format and saving.
+        if self._tgis_backend:
+            return self._tgis_backend.get_client(self.base_model_name)
 
     @classmethod
     def load(cls, model_path: str, load_backend: BackendBase) -> "PeftPromptTuningTGIS":
@@ -182,7 +192,7 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             )
 
     # pylint: disable=duplicate-code
-    @TextGenerationTask.taskmethod()
+    @TextGenerationTask.taskmethod(context_arg="context")
     def run(
         self,
         text: str,
@@ -206,6 +216,7 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
         generated_tokens: bool = True,
         token_logprobs: bool = True,
         token_ranks: bool = True,
+        context: Optional[RuntimeServerContextType] = None,
     ) -> GeneratedTextResult:
         f"""Run inference against the model running in TGIS.
 
@@ -221,6 +232,8 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             self.enable_backend,
             "Backend must be configured and loaded with this module before executing `run` call.",
         )
+        self._register_model_connection_with_context(context)
+
         verbalized_text = render_verbalizer(self.verbalizer, {"input": text})
         return self.tgis_generation_client.unary_generate(
             text=verbalized_text,
@@ -244,7 +257,7 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             stop_sequences=stop_sequences,
         )
 
-    @TextGenerationTask.taskmethod(output_streaming=True)
+    @TextGenerationTask.taskmethod(output_streaming=True, context_arg="context")
     def run_stream_out(
         self,
         text: str,
@@ -268,6 +281,7 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
         generated_tokens: bool = True,
         token_logprobs: bool = True,
         token_ranks: bool = True,
+        context: Optional[RuntimeServerContextType] = None,
     ) -> Iterable[GeneratedTextStreamResult]:
         f"""Run output stream inferencing against the model running in TGIS
 
@@ -283,6 +297,9 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             "Backend must be configured and loaded with this module \
             before executing `run_stream_out` call.",
         )
+
+        self._register_model_connection_with_context(context)
+
         verbalized_text = render_verbalizer(self.verbalizer, {"input": text})
         return self.tgis_generation_client.stream_generate(
             text=verbalized_text,
@@ -306,10 +323,11 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             stop_sequences=stop_sequences,
         )
 
-    @TokenizationTask.taskmethod()
+    @TokenizationTask.taskmethod(context_arg="context")
     def run_tokenizer(
         self,
         text: str,
+        context: Optional[RuntimeServerContextType] = None,
     ) -> TokenizationResults:
         """Run tokenization task against the model running in TGIS.
 
@@ -320,6 +338,20 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             TokenizationResults
                 The token count
         """
+
+        self._register_model_connection_with_context(context)
+
         return self.tgis_generation_client.unary_tokenize(
             text=text,
         )
+
+    def _register_model_connection_with_context(
+        self, context: Optional[RuntimeServerContextType]
+    ):
+        """
+        Register a remote model connection with the configured TGISBackend if there is
+        a context override provided.
+        """
+        if self._tgis_backend:
+            self._tgis_backend.handle_runtime_context(self.base_model_name, context)
+            self._model_loaded = True

--- a/caikit_nlp/modules/text_generation/text_generation_tgis.py
+++ b/caikit_nlp/modules/text_generation/text_generation_tgis.py
@@ -14,6 +14,7 @@
 
 
 # Standard
+from functools import cached_property
 from typing import Iterable, List, Optional, Tuple, Union
 import os
 
@@ -30,6 +31,7 @@ from caikit.interfaces.nlp.data_model import (
     TokenizationResults,
 )
 from caikit.interfaces.nlp.tasks import TextGenerationTask, TokenizationTask
+from caikit.interfaces.runtime.data_model import RuntimeServerContextType
 from caikit_tgis_backend import TGISBackend
 import alog
 
@@ -86,28 +88,33 @@ class TextGenerationTGIS(ModuleBase):
         # Set _model_loaded as False by default. This will only get set to True if
         # we enable the tgis_backend and we are able to fetch the client successfully.
         self._model_loaded = False
-        # Configure the internal client
-        # NOTE: This is made optional for the cases where we do not need to execute `.run` function
-        # for example, bootstrapping a model to caikit format and saving.
-        self._client = None
         if tgis_backend:
-            self._client = tgis_backend.get_client(model_name)
-            # mark that the model is loaded so that we can unload it later
-            self._model_loaded = True
             self.tgis_backend = tgis_backend
 
+        self._tgis_backend = tgis_backend
         self._bos_token = bos_token
         self._sep_token = sep_token
         self._eos_token = eos_token
         self._pad_token = pad_token
-        self.tgis_generation_client = TGISGenerationClient(
-            self.model_name, self._eos_token, self._client, self.PRODUCER_ID
-        )
 
     def __del__(self):
         # nothing to unload if we didn't finish loading
-        if self._model_loaded and self.tgis_backend:
-            self.tgis_backend.unload_model(self.model_name)
+        if self._model_loaded and self._tgis_backend:
+            self._tgis_backend.unload_model(self.model_name)
+
+    @cached_property
+    def _client(self):
+        # Lazily configure/create the internal tgis backend client
+        if self._tgis_backend:
+            return self._tgis_backend.get_client(self.model_name)
+
+    @cached_property
+    def tgis_generation_client(self):
+        # Lazily create the generation client
+        # This in turn calls self._client which also lazily gets the tgis backend client
+        return TGISGenerationClient(
+            self.model_name, self._eos_token, self._client, self.PRODUCER_ID
+        )
 
     @classmethod
     def bootstrap(cls, model_path: str, load_backend: Union[BackendBase, None] = None):
@@ -207,7 +214,7 @@ class TextGenerationTGIS(ModuleBase):
             )
 
     # pylint: disable=duplicate-code
-    @TextGenerationTask.taskmethod()
+    @TextGenerationTask.taskmethod(context_arg="context")
     def run(
         self,
         text: str,
@@ -231,6 +238,7 @@ class TextGenerationTGIS(ModuleBase):
         generated_tokens: bool = True,
         token_logprobs: bool = True,
         token_ranks: bool = True,
+        context: Optional[RuntimeServerContextType] = None,
     ) -> GeneratedTextResult:
         f"""Run inference against the model running in TGIS.
 
@@ -240,6 +248,8 @@ class TextGenerationTGIS(ModuleBase):
             GeneratedTextResult
                 Generated text result produced by TGIS.
         """
+        self._register_model_connection_with_context(context)
+
         if self._model_loaded:
             return self.tgis_generation_client.unary_generate(
                 text=text,
@@ -263,7 +273,7 @@ class TextGenerationTGIS(ModuleBase):
                 stop_sequences=stop_sequences,
             )
 
-    @TextGenerationTask.taskmethod(output_streaming=True)
+    @TextGenerationTask.taskmethod(output_streaming=True, context_arg="context")
     def run_stream_out(
         self,
         text: str,
@@ -287,6 +297,7 @@ class TextGenerationTGIS(ModuleBase):
         generated_tokens: bool = True,
         token_logprobs: bool = True,
         token_ranks: bool = True,
+        context: Optional[RuntimeServerContextType] = None,
     ) -> Iterable[GeneratedTextStreamResult]:
         f"""Run output stream inferencing for text generation module.
 
@@ -295,6 +306,7 @@ class TextGenerationTGIS(ModuleBase):
         Returns:
             Iterable[GeneratedTextStreamResult]
         """
+        self._register_model_connection_with_context(context)
 
         if self._model_loaded:
             return self.tgis_generation_client.stream_generate(
@@ -319,10 +331,11 @@ class TextGenerationTGIS(ModuleBase):
                 stop_sequences=stop_sequences,
             )
 
-    @TokenizationTask.taskmethod()
+    @TokenizationTask.taskmethod(context_arg="context")
     def run_tokenizer(
         self,
         text: str,
+        context: Optional[RuntimeServerContextType] = None,
     ) -> TokenizationResults:
         """Run tokenization task against the model running in TGIS.
 
@@ -333,7 +346,20 @@ class TextGenerationTGIS(ModuleBase):
             TokenizationResults
                 The token count
         """
+        self._register_model_connection_with_context(context)
+
         if self._model_loaded:
             return self.tgis_generation_client.unary_tokenize(
                 text=text,
             )
+
+    def _register_model_connection_with_context(
+        self, context: Optional[RuntimeServerContextType]
+    ):
+        """
+        Register a remote model connection with the configured TGISBackend if there is
+        a context override provided.
+        """
+        if self._tgis_backend:
+            self._tgis_backend.handle_runtime_context(self.model_name, context)
+            self._model_loaded = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit[runtime-grpc,runtime-http]>=0.26.17,<0.27.0",
-    "caikit-tgis-backend>=0.1.27,<0.2.0",
+    "caikit[runtime-grpc,runtime-http]>=0.26.34,<0.27.0",
+    "caikit-tgis-backend>=0.1.34,<0.2.0",
     # TODO: loosen dependencies
     "grpcio>=1.62.2", # explicitly pin grpc dependencies to a recent version to avoid pip backtracking
     "grpcio-reflection>=1.62.2",

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,8 +1,8 @@
-"""Helpful fixtures for configuring individual unit tests.
-"""
+"""Helpful fixtures for configuring individual unit tests."""
+
 # Standard
 from contextlib import contextmanager
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Union
 from unittest import mock
 import json
 import os
@@ -191,6 +191,7 @@ def requires_determinism(request):
 
 ### Common TGIS stub classes
 
+
 # Helper stubs / mocks; we use these to patch caikit so that we don't actually
 # test the TGIS backend directly, and instead stub the client and inspect the
 # args that we pass to it.
@@ -342,3 +343,15 @@ def temp_config(**overrides):
 
     with mock.patch.object(caikit.config.config, "_IMMUTABLE_CONFIG", local_config):
         yield local_config
+
+
+class TestServicerContext:
+    """
+    A dummy class for mimicking ServicerContext invocation metadata storage.
+    """
+
+    def __init__(self, metadata: dict[str, Union[str, bytes]]):
+        self.metadata = metadata
+
+    def invocation_metadata(self):
+        return list(self.metadata.items())

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -197,6 +197,21 @@ def test_save_load_and_run():
     _assert_is_expected_embedding_result(result)
 
 
+def test_public_model_info():
+    """Check if we can get model info successfully"""
+    model_id = "model_id"
+    with tempfile.TemporaryDirectory(suffix="-1st") as model_dir:
+        model_path = os.path.join(model_dir, model_id)
+        BOOTSTRAPPED_MODEL.save(model_path)
+        new_model = EmbeddingModule.load(model_path)
+
+    result = new_model.public_model_info
+    assert "max_seq_length" in result
+    assert "sentence_embedding_dimension" in result
+    assert type(result["max_seq_length"]) is int
+    assert type(result["sentence_embedding_dimension"]) is int
+
+
 @pytest.mark.parametrize(
     "model_path", ["", " ", " " * 100], ids=["empty", "space", "spaces"]
 )

--- a/tests/toolkit/text_generation/test_tgis_utils.py
+++ b/tests/toolkit/text_generation/test_tgis_utils.py
@@ -14,10 +14,12 @@
 """
 Tests for tgis_utils
 """
+
 # Standard
 from typing import Iterable, Optional, Type
 
 # Third Party
+import fastapi
 import grpc
 import grpc._channel
 import pytest
@@ -25,10 +27,12 @@ import pytest
 # First Party
 from caikit.core.data_model import ProducerId
 from caikit.core.exceptions.caikit_core_exception import CaikitCoreException
+from caikit.interfaces.runtime.data_model import RuntimeServerContextType
 from caikit_tgis_backend.protobufs import generation_pb2
 
 # Local
 from caikit_nlp.toolkit.text_generation import tgis_utils
+from tests.fixtures import TestServicerContext
 
 ## Helpers #####################################################################
 
@@ -127,3 +131,48 @@ def test_TGISGenerationClient_rpc_errors(status_code, method):
     )
     rpc_err = context.value.__context__
     assert isinstance(rpc_err, grpc.RpcError)
+
+
+# NOTE: This test is preserved in caikit-nlp despite being duplicated in
+# caikit-tgis-backend so that we guarantee that the functionality is accessible
+# in a version-compatible way here.
+@pytest.mark.parametrize(
+    argnames=["context", "route_info"],
+    argvalues=[
+        (
+            fastapi.Request(
+                {
+                    "type": "http",
+                    "headers": [
+                        (tgis_utils.ROUTE_INFO_HEADER_KEY.encode(), b"sometext")
+                    ],
+                }
+            ),
+            "sometext",
+        ),
+        (
+            fastapi.Request(
+                {"type": "http", "headers": [(b"route-info", b"sometext")]}
+            ),
+            None,
+        ),
+        (
+            TestServicerContext({tgis_utils.ROUTE_INFO_HEADER_KEY: "sometext"}),
+            "sometext",
+        ),
+        (
+            TestServicerContext({"route-info": "sometext"}),
+            None,
+        ),
+        ("should raise ValueError", None),
+        (None, None),
+        # Uncertain how to create a grpc.ServicerContext object
+    ],
+)
+def test_get_route_info(context: RuntimeServerContextType, route_info: Optional[str]):
+    if not isinstance(context, (fastapi.Request, grpc.ServicerContext, type(None))):
+        with pytest.raises(TypeError):
+            tgis_utils.get_route_info(context)
+    else:
+        actual_route_info = tgis_utils.get_route_info(context)
+        assert actual_route_info == route_info


### PR DESCRIPTION
- :thread: Add timeout configuration for TGIS streaming request as an experiment
- :sparkles: Add tgis req timeout as configurable parameter
- :white_check_mark: Fix tgis client fixture for acceting kwargs
- :art: Fix formatting
- :bug::white_check_mark: Fix fixture for tgis tests
- Expose model information for embeddings service
- Bump lower caikit version
- added logging around tgis timout config setting
- Update caikit_nlp/toolkit/text_generation/tgis_utils.py
- Update caikit_nlp/toolkit/text_generation/tgis_utils.py
- fixed formatting
- add get_route_info
- lazily create model_connection and _client
- lazy load model_connection and tgis client for peft
- remove commented out code
- Address review comments
- Expand test_get_route_info
- Lazily create generation client
- Update minimum caikit-tgis-backend version
- Add debug logs
- Linting
- linting
- Update caikit_nlp/toolkit/text_generation/tgis_utils.py
- review comments
- remove unreachable code
- RouteInfoFromBackend: Forward get_route_info and ROUTE_INFO_HEADER_KEY from backend
- RouteInfoFromBackend: Bump caikit-tgis-backend
- RouteInfoFromBackend: Bump caikit for context registration in backend
- RouteInfoFromBackend: Remove unused imports
