### PR TITLE
Add script to wait for the model to appear when using KServe Modelcar

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 !pyproject.toml
 !tox.ini
 !.git
+!scripts/wait-modelcar.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 COPY LICENSE /opt/caikit/
 COPY README.md /opt/caikit/
+COPY --chown=0:0 --chmod=554 scripts/wait-modelcar.sh /opt/caikit/
 
 RUN groupadd --system caikit --gid 1001 && \
     adduser --system --uid 1001 --gid 0 --groups caikit \
@@ -48,4 +49,5 @@ ENV RUNTIME_LIBRARY=caikit_nlp
 VOLUME ["/caikit/"]
 WORKDIR /caikit
 
+ENTRYPOINT ["/opt/caikit/wait-modelcar.sh"]
 CMD ["python"]

--- a/scripts/wait-modelcar.sh
+++ b/scripts/wait-modelcar.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "${MODEL_INIT_MODE}" = "async" ] ; then
+  echo "Waiting for model files (modelcar) to be present..."
+  until test -e /mnt/models; do
+    sleep 1
+  done
+
+  echo "Model files are now available."
+fi
+
+echo "Starting model server..."
+eval $@
+


### PR DESCRIPTION
When using OCI containers for model storage in KServe (modelcar), there is the possibility that the model server starts before the model has been fully downloaded. When this happens, the model server would terminate with error because the model path is empty.

This adds a small script to wait for the cluster to fully download the model container before invoking the model server. The waiting is triggered when the MODEL_INIT_MODE environment variable is set to "async".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
