### PR TITLE
Convert tensor dtype to float64

### DIFF
--- a/caikit_nlp/modules/text_classification/sequence_classification.py
+++ b/caikit_nlp/modules/text_classification/sequence_classification.py
@@ -185,7 +185,7 @@ class SequenceClassification(ModuleBase):
 
         softmax = torch.nn.Softmax(dim=1)
         raw_scores = softmax(logits)
-        scores = raw_scores.numpy()
+        scores = raw_scores.double().numpy()
         num_labels = self.model.num_labels
         num_texts = 1  # str
         if isinstance(text, List):


### PR DESCRIPTION
When the `.results` or `to_json()` method is called on models bootstrapped using the SequenceClassification module it returns an error. For example:
```
MODEL_ID = "JungleLee/bert-toxic-comment-classification"
BOOTSTRAPPED_TOXICITY_CLASSIFIER = SequenceClassification.bootstrap(MODEL_ID)
classification_results = BOOTSTRAPPED_TOXICITY_CLASSIFIER.run(DOCUMENT)
print(classification_results.results)
```

Output:
```
TypeError: Object of type <class 'numpy.float32'> is not JSON serializable
```

This PR resolves this error by converting the tensor data type to `float64` before converting it to a numpy array.
