### PR TITLE
Fix: Ensure labels.json is included in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 !pyproject.toml
 !tox.ini
 !.git
+!labels.json


### PR DESCRIPTION
The konflux build build is failing with the following error:

`Error: building at STEP "COPY labels.json /root/buildinfo/labels.json":  no items matching glob "/var/workdir/source/labels.json" copied  (1 filtered out using /var/workdir/source/.dockerignore): no such file or directory`

This occurred because .dockerignore had a catch-all rule (*) that excluded all files from the build context, and labels.json was not explicitly unignored.

This error was not caused by the Dockerfile itself, which does not include a COPY labels.json instruction. Instead, the error occurs specifically in konflux that injects this additional step which attempts to copy labels.json into the image for metadata purposes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build context to include labels.json by adjusting ignore rules. The file is now explicitly included during image builds while all other ignore patterns remain unchanged. This makes label data available to the build process and helps produce images with the intended metadata. No user-facing functionality is affected, and runtime behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->