### PR TITLE
Fix fastapi CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install /tmp/caikit_nlp*.whl && \
     rm /tmp/caikit_nlp*.whl && \
     microdnf remove -y gcc python3-devel && \
+    pip install fastapi>=0.115.4 && \
     microdnf clean all
 
 COPY LICENSE /opt/caikit/


### PR DESCRIPTION
Addresses : [RHOAIENG-38838](https://issues.redhat.com/browse/RHOAIENG-38838)

To address this CVE's [GHSA-7f5h-v6xp-fcq8](https://github.com/Kludex/starlette/security/advisories/GHSA-7f5h-v6xp-fcq8)